### PR TITLE
Add dns to fortify -> Plat-198

### DIFF
--- a/modules/fortify-server/fortify-user-data.sh
+++ b/modules/fortify-server/fortify-user-data.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 
 # The following variables are replaced with terraform interpolation
-/home/ec2-user/run-fortify-ssc.sh ${fortify_db_name} ${fortify_jdbc_url} ${fortify_db_driver_class} ${fortify_db_username} ${fortify_db_password} ${fortify_db_endpoint} ${root_db_name}> /home/ec2-user/run-fortify-ssc.out 2>&1
+/home/ec2-user/run-fortify-ssc.sh ${fortify_db_name} \
+                                  ${fortify_jdbc_url} \
+                                  ${fortify_db_driver_class} \
+                                  ${fortify_db_username} \
+                                  ${fortify_db_password} \
+                                  ${fortify_db_endpoint} \
+                                  ${root_db_name} \
+                                  ${fortify_dns} > /home/ec2-user/run-fortify-ssc.out 2>&1

--- a/modules/fortify-server/main.tf
+++ b/modules/fortify-server/main.tf
@@ -22,6 +22,7 @@ resource "aws_instance" "fortify" {
   iam_instance_profile        = "${aws_iam_instance_profile.instance_profile.name}"
   tags {
       Name = "${var.instance_name}"
+      SAN = "${var.san}"
   }
 }
 

--- a/modules/fortify-server/main.tf
+++ b/modules/fortify-server/main.tf
@@ -66,6 +66,7 @@ data "template_file" "fortify_user_data" {
     fortify_db_username         = "${var.fortify_db_username}"
     fortify_db_password         = "${var.fortify_db_password}"
     fortify_db_driver_class     = "${var.fortify_db_driver_class}"
+    fortify_dns                 = "${var.san}"
   }
 }
 

--- a/modules/fortify-server/variables.tf
+++ b/modules/fortify-server/variables.tf
@@ -10,7 +10,7 @@ variable "instance_name" {
 
 variable "ami_id" {
   description = "The ID of the AMI to run in this cluster."
-}  
+}
 
 variable "instance_type" {
   description = "The type of EC2 Instances to run for the fortify instance (e.g. m4.large)"
@@ -32,7 +32,7 @@ variable "subnet_ids" {
 
 variable "fortify_db_username" {
   description = "The database username with which to authenticate"
-} 
+}
 
 variable "fortify_db_password" {
   description = "The database password with which to authenticate"
@@ -47,6 +47,10 @@ variable "fortify_db_driver_class" {
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
+variable "san" {
+  description = "The value for the SAN tag of the instance"
+  default     = "fortify.internal.vets-api.gov"
+}
 
 variable "root_db_name" {
   description = "The name of the database created by rds on when it first comes up"
@@ -139,18 +143,3 @@ variable "instance_profile_path" {
   description = "Path in which to create the IAM instance profile"
   default     = "/"
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/packer/run-fortify-ssc.sh
+++ b/packer/run-fortify-ssc.sh
@@ -4,7 +4,7 @@
 # Set all of the commandline variables
 # supplied from fortify-user-data.sh
 # ##########################################
-NUMBER_CLI_ARGS=7
+NUMBER_CLI_ARGS=8
 
 # Check that we have the right amount of args
 if [ "$#" -ne $NUMBER_CLI_ARGS ]; then
@@ -20,6 +20,7 @@ fortify_db_username=$4
 fortify_db_password=$5
 fortify_db_endpoint=$6
 root_db_name=$7
+fortify_dns=$8
 
 
 # Output the variables for debugging
@@ -30,6 +31,7 @@ echo "fortify_db_username=$fortify_db_username"
 echo "fortify_db_password=$fortify_db_password"
 echo "fortify_db_endpoint=$fortify_db_endpoint"
 echo "root_db_name=$root_db_name"
+echo "fortify_dns=$fortify_dns"
 
 
 # ##########################################
@@ -43,9 +45,8 @@ sudo cp /fortify.license /root/.fortify/fortify.license
 # ##########################################
 fortify_config_properties=/root/.fortify/ssc/conf/app.properties
 fortify_data_properties=/root/.fortify/ssc/conf/datasource.properties
-export fortify_ip=`hostname -I | xargs`
 
-sed -i "s|^host.url=|host.url=http://$fortify_ip:8080/ssc|g" $fortify_config_properties
+sed -i "s|^host.url=|host.url=http://$fortify_dns:8080/ssc|g" $fortify_config_properties
 sed -i 's|^host.validation=false|host.validation=true|g' $fortify_config_properties
 sed -i "s|^jdbc.url=|jdbc.url=$fortify_jdbc_url?connectionCollation=latin1_general_cs|g" $fortify_data_properties
 sed -i "s|^db.driver.class=|db.driver.class=$fortify_db_driver_class|g" $fortify_data_properties


### PR DESCRIPTION
- adds the SAN tag to the instance so that the fortify ssc instance will have dns.
- configures SSC so that the url is to the dns instead of the IP