### PR TITLE
Fortify utility -> PLAT-177 rework

### DIFF
--- a/modules/jenkins-fortify-slave/main.tf
+++ b/modules/jenkins-fortify-slave/main.tf
@@ -55,6 +55,8 @@ module "security_group_rules" {
   source = "../jenkins-node-security-group-rules"
   security_group_id                  = "${aws_security_group.fortify_security_group.id}"
   allowed_ssh_cidr_blocks        = ["${var.allowed_ssh_cidr_blocks}"]
+  jenkins_master_security_group_id   = "${var.jenkins_master_security_group_id}"
+  jenkins_master_http_port           = "${var.jenkins_master_http_port}"
 }
 
 

--- a/modules/jenkins-fortify-slave/outputs.tf
+++ b/modules/jenkins-fortify-slave/outputs.tf
@@ -1,3 +1,8 @@
 output "jenkins_fortify_node_ip" {
   value = "${aws_instance.jenkins_fortify_node.private_ip}"
 }
+
+output "security_group_id" {
+  value = "${aws_security_group.fortify_security_group.id}"
+}
+

--- a/modules/jenkins-fortify-slave/variables.tf
+++ b/modules/jenkins-fortify-slave/variables.tf
@@ -39,10 +39,20 @@ variable "fortify_ssh_password" {
   description = "The password that jenkins will use to authenticate over ssh with the fortify agent"
 }
 
+variable "jenkins_master_security_group_id" {
+  description = "The security group ID of the Jenkins Master Instance, so we can grant the fortify agent access to some of its ports"
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 # These parameters have reasonable defaults.
 # ---------------------------------------------------------------------------------------------------------------------
+variable "jenkins_master_http_port" {
+  description = "The HTTP port of the jenkins master instance. Usually 8080"
+  default     = "8080"
+}
+
+
 variable "fortify_bucket_name" {
   description = "The name of the bucket that holds the fortify software and license"
   default      = "fortify-utility"

--- a/modules/jenkins-node-security-group-rules/main.tf
+++ b/modules/jenkins-node-security-group-rules/main.tf
@@ -23,3 +23,26 @@ resource "aws_security_group_rule" "allow_all_outbound" {
   cidr_blocks = ["0.0.0.0/0"]
   security_group_id = "${var.security_group_id}"
 }
+
+
+# Add a rule to allow the fortify agent to make jenkins api calls
+resource "aws_security_group_rule" "allow_fortify_agent_inbound" {
+  type       = "ingress"
+  from_port  = "${var.jenkins_master_http_port}"
+  to_port    = "${var.jenkins_master_http_port}"
+  protocol   = "all"
+  source_security_group_id = "${var.security_group_id}"
+  security_group_id        = "${var.jenkins_master_security_group_id}"
+}
+
+
+# Add a rule to allow the fortify agent have a slave connection to the jenkins master
+resource "aws_security_group_rule" "allow_fortify_agent_ssh_inbound" {
+  type       = "ingress"
+  from_port  = "${var.ssh_port}"
+  to_port    = "${var.ssh_port}"
+  protocol   = "all"
+  source_security_group_id = "${var.security_group_id}"
+  security_group_id        = "${var.jenkins_master_security_group_id}"
+}
+

--- a/modules/jenkins-node-security-group-rules/main.tf
+++ b/modules/jenkins-node-security-group-rules/main.tf
@@ -30,7 +30,7 @@ resource "aws_security_group_rule" "allow_fortify_agent_inbound" {
   type       = "ingress"
   from_port  = "${var.jenkins_master_http_port}"
   to_port    = "${var.jenkins_master_http_port}"
-  protocol   = "all"
+  protocol   = "tcp"
   source_security_group_id = "${var.security_group_id}"
   security_group_id        = "${var.jenkins_master_security_group_id}"
 }
@@ -41,7 +41,7 @@ resource "aws_security_group_rule" "allow_fortify_agent_ssh_inbound" {
   type       = "ingress"
   from_port  = "${var.ssh_port}"
   to_port    = "${var.ssh_port}"
-  protocol   = "all"
+  protocol   = "tcp"
   source_security_group_id = "${var.security_group_id}"
   security_group_id        = "${var.jenkins_master_security_group_id}"
 }

--- a/modules/jenkins-node-security-group-rules/variables.tf
+++ b/modules/jenkins-node-security-group-rules/variables.tf
@@ -9,10 +9,18 @@ variable "security_group_id" {
   description = "The ID of the security group to which we should add the Fortify security group rules"
 }
 
+variable "jenkins_master_security_group_id" {
+  description = "The ID of the Jenkins master instance that will allow http and ssh access to this agent"
+}
 
 ###############################################################################
 # OPTIONAL VARIABLES
 ###############################################################################
+variable "jenkins_master_http_port" {
+  description = "The Jenkins Master port that we need to open up to allow the foritfy agent HTTP access"
+  default     = "8080"
+}
+
 variable "ssh_port" {
   description = "The port for ssh connections. Usually port 22"
   default     = 22


### PR DESCRIPTION
- Add two security group rules to the jenkins master security group to allow the fortify agent access through the jenkins master instance